### PR TITLE
Expand LLA seed bundle tracker

### DIFF
--- a/REQUESTS.md
+++ b/REQUESTS.md
@@ -1,0 +1,14 @@
+## Pending Requests
+- Awaiting R-SYN bundle: Issues #10 (Synthesis), #11 (Architecture Recommendations), #12 (Roadmap).
+- If R-SYN is delayed, send R-ALG (breakout naming function + types) as a fallback starter payload.
+
+## Seed Bundle for LLA (HNC/HOSS design)
+- [ ] R-SYN: Issue #10 body
+- [ ] R-SYN: Issue #11 body
+- [ ] R-SYN: Issue #12 body
+- [ ] R-ALG: Breakout naming function + types (fallback if R-SYN delayed)
+- [ ] R-CRD: Wiring Diagram CRD specimen (smallest valid example)
+- [ ] R-SW: Switch profile excerpt (1 real physical + breakout support)
+- [ ] R-VAL: hhfab validate expectations (1 happy, 1 failure case)
+- [ ] D-ENV: Target runtime constraints (version pins, must-use tools)
+- [ ] R-GAPS: Known deltas vs hhfab vlab gen (bullets)


### PR DESCRIPTION
## Summary
- add fallback instructions for providing R-ALG if R-SYN is delayed
- record the full seed bundle checklist with explicit artifacts to gather

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68db65ba60f0832eb77b65ef4ff57db9