### PR TITLE
ci: scaffold review-kit validation stubs

### DIFF
--- a/.github/actions/hhfab-validate/action.yml
+++ b/.github/actions/hhfab-validate/action.yml
@@ -1,0 +1,25 @@
+name: hhfab validate (stub)
+description: Minimal stub that runs scripts/hhfab-smoke.sh and emits a JSON summary.
+author: HOSS Automation
+inputs:
+  script:
+    description: Relative path to smoke script
+    required: false
+    default: scripts/hhfab-smoke.sh
+  working-directory:
+    description: Repo subdir to run in
+    required: false
+    default: .
+runs:
+  using: composite
+  steps:
+    - name: Run smoke
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -Eeuo pipefail
+        script="${{ inputs.script }}"
+        if [[ ! -x "$script" ]]; then chmod +x "$script"; fi
+        bash "$script"
+        # Surface path for downstream steps
+        echo "summary_path=$(jq -r '.artifact' .artifacts/review-kit/summary.json 2>/dev/null || echo .artifacts/review-kit/summary.json)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,29 @@
+name: actionlint
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+      - name: Set up Go (for actionlint)
+        uses: actions/setup-go@4d1edbf9f77cb1be1dfc84a3aa6bce4a0e753135
+        with:
+          go-version: '1.21'
+      - name: Install actionlint
+        run: |
+          set -Eeuo pipefail
+          export GOBIN="$RUNNER_TEMP/bin"
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.6.26
+          echo "$GOBIN" >> "$GITHUB_PATH"
+      - name: Run actionlint
+        run: actionlint -color never

--- a/.github/workflows/review-kit.yml
+++ b/.github/workflows/review-kit.yml
@@ -1,0 +1,33 @@
+name: review-kit
+on:
+  pull_request:
+    paths:
+      - 'scripts/**'
+      - '.github/actions/**'
+      - '.github/workflows/review-kit.yml'
+      - 'contracts/**'
+      - 'samples/**'
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+      - name: Run minimal validator stub
+        id: run
+        uses: ./.github/actions/hhfab-validate
+      - name: Print summary
+        if: always()
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          p=".artifacts/review-kit/summary.json"
+          test -f "$p" || { echo "summary missing ($p)"; exit 0; }
+          echo "----- summary.json -----"
+          cat "$p" | sed 's/.*/ &/'
+          echo "------------------------"

--- a/docs/research/gpt-5-codex-prep-research-dossier.md
+++ b/docs/research/gpt-5-codex-prep-research-dossier.md
@@ -1,0 +1,28 @@
+# Prep Research Dossier – gpt-5-codex (prep-research)
+
+## Scope view
+- Repository root currently only contains `.gitignore` and `README.md`; there are no source, workflow, or script directories present. 【F:.gitignore†L1-L21】【18e456†L1-L2】
+- No `.github/` directory exists yet, so there are no workflows, composite actions, or problem matchers checked into the repo. 【0bda2f†L1-L2】
+- Attempting to invoke the expected smoke helper under `scripts/` fails because the directory (and script) has not been created. 【9f4286†L1-L2】
+
+## Inputs / Outputs
+- Because the `.github/workflows` tree is absent, there are no declared workflow inputs, environment variables, or artifacts defined for validator runs today. 【0bda2f†L1-L2】
+- The missing `scripts/hhfab-smoke.sh` helper means there is currently no local entry point that would emit JSON summaries or other artifacts for smoke validation. 【9f4286†L1-L2】
+
+## Local runs
+- `actionlint -color never` exits with `command not found`, confirming the validator tool is not yet installed in the environment; no workflow syntax could be checked locally. 【9fe699†L1-L2】
+- Running `bash scripts/hhfab-smoke.sh || true` reports `No such file or directory`, so the smoke harness is not available for dry-runs. 【9f4286†L1-L2】
+
+## CI guardrails & gaps
+- With no `.github/workflows` defined, there are currently no pinned GitHub Actions, container digest enforcement, or rootless/RO job settings in place. 【0bda2f†L1-L2】
+- The absence of the smoke script also means there is no local enforcement of no-network, digest-pinned containers, or other guardrails described in HH FAB standards. 【9f4286†L1-L2】
+
+## Minimal change plan (pending implementation phase)
+1. `feat: bootstrap hhfab validator action` – add `.github/actions/hhfab-validate/action.yml` implementing the composite action expected by the workflows. 【0bda2f†L1-L2】
+2. `ci: add review-kit workflow scaffolding` – introduce `.github/workflows/review-kit.yml` (and related jobs) with pinned action SHAs and strict container flags. 【0bda2f†L1-L2】
+3. `ci: add smoke validation script` – create `scripts/hhfab-smoke.sh` to run validators locally with documented outputs. 【9f4286†L1-L2】
+
+## Risks / Open questions
+- Required validator behavior, environment variables, and artifact formats remain unspecified because no prior implementation exists in the repo; additional product guidance is needed. 【18e456†L1-L2】
+- Local tooling such as `actionlint` is not installed in the container image, so we will need to vendor a binary or document installation steps before running checks. 【9fe699†L1-L2】
+- Without existing workflows, we have no examples of the expected problem matcher wiring or summary outputs to match, increasing the risk of mismatched formatting. 【0bda2f†L1-L2】

--- a/scripts/hhfab-smoke.sh
+++ b/scripts/hhfab-smoke.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ART_DIR=".artifacts/review-kit"
+SUMMARY="${ART_DIR}/summary.json"
+mkdir -p "${ART_DIR}"
+
+status="skipped"
+reason="tooling_missing"
+
+# Optional: respect strict mode (no network, RO fs would be handled by CI runner)
+STRICT_MODE="${HHFAB_STRICT:-0}"
+
+# If hhfab exists, run a no-op help/version to prove plumbing works
+if command -v hhfab >/dev/null 2>&1; then
+  status="ok"
+  reason="dry_run"
+  hhfab version || true
+else
+  echo "WARN: 'hhfab' not found; emitting skipped summary" >&2
+fi
+
+# Minimal, structured output for CI comments
+cat > "${SUMMARY}" <<JSON
+{
+  "strictMode": ${STRICT_MODE},
+  "status": "${status}",
+  "reason": "${reason}",
+  "artifact": "${SUMMARY}"
+}
+JSON
+
+echo "summary -> ${SUMMARY}"


### PR DESCRIPTION
## Summary
- add a minimal hhfab smoke script that emits a structured summary for CI consumers
- introduce a composite action to reuse the smoke script and surface the summary path
- wire up review-kit and actionlint pull-request workflows with pinned dependencies

## Testing
- `bash scripts/hhfab-smoke.sh`


------
https://chatgpt.com/codex/tasks/task_b_68db8ea06510832e82a04ea51afce9e4