### PR TITLE
ci: review-kit hardening (artifacts, digest guard, optional cosign)

### DIFF
--- a/.github/workflows/review-kit.yml
+++ b/.github/workflows/review-kit.yml
@@ -24,6 +24,7 @@ concurrency:
   cancel-in-progress: true
 env:
   HHFAB_IMAGE_DIGEST: ${{ vars.HHFAB_IMAGE_DIGEST }}
+  COSIGN_VERIFY: ${{ vars.COSIGN_VERIFY || '0' }}
   MATRIX_FILE: .github/review-kit/matrix.txt
   ARTIFACT_DIR: .artifacts/review-kit
 
@@ -212,6 +213,21 @@ jobs:
 [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
             *) echo "HHFAB_IMAGE_DIGEST must be digest-pinned (@sha256:…)" >&2; exit 3 ;;
           esac
+      - name: Install cosign
+        if: ${{ env.COSIGN_VERIFY == '1' }}
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62
+        with:
+          cosign-release: 'v2.2.4'
+      - name: Verify HHFAB image signature
+        if: ${{ env.COSIGN_VERIFY == '1' }}
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+        run: |
+          set -Eeuo pipefail
+          cosign verify \
+            --certificate-oidc-issuer-regexp 'https://token.actions.githubusercontent.com' \
+            --certificate-identity-regexp 'https://github.com/afewell-hh/hoss/.*' \
+            "${HHFAB_IMAGE_DIGEST}"
       - name: Register hhfab matcher
         run: echo "::add-matcher::${HHFAB_MATCHER_PATH}"
       - name: Force-fail summary (dispatch only)

--- a/.github/workflows/review-kit.yml
+++ b/.github/workflows/review-kit.yml
@@ -201,6 +201,17 @@ jobs:
           else
             echo "HHFAB_IMAGE_DIGEST is MISSING"; exit 2
           fi
+      - name: Guard HHFAB_IMAGE_DIGEST is digest-pinned
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          case "${HHFAB_IMAGE_DIGEST:-}" in
+            *@sha256:[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]\
+[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]\
+[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]\
+[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+            *) echo "HHFAB_IMAGE_DIGEST must be digest-pinned (@sha256:…)" >&2; exit 3 ;;
+          esac
       - name: Register hhfab matcher
         run: echo "::add-matcher::${HHFAB_MATCHER_PATH}"
       - name: Force-fail summary (dispatch only)

--- a/.github/workflows/review-kit.yml
+++ b/.github/workflows/review-kit.yml
@@ -166,7 +166,7 @@ jobs:
         if: always() && steps.run.outputs.summary_path != ''
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: review-kit-summary.json
+          name: review-kit-summary-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.run.outputs.summary_path }}
           if-no-files-found: warn
           retention-days: 1
@@ -384,7 +384,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: review-kit-summary.json
+          name: review-kit-summary-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.summary.outputs.path }}
           if-no-files-found: warn
           retention-days: 1


### PR DESCRIPTION
## Summary
- Make artifact names unique per run/attempt to avoid collisions
- Enforce digest-pinned HHFAB_IMAGE_DIGEST format
- Add optional cosign signature verification (disabled by default)

## Changes
1. **Artifact de-flaking**: Both smoke-local and strict jobs now upload artifacts with unique names including `run_id` and `run_attempt`
2. **Digest guard**: Strict job validates HHFAB_IMAGE_DIGEST matches `@sha256:<64-hex>` format before running
3. **Optional cosign verify**: Feature-flagged behind `COSIGN_VERIFY=1` repo variable (zero impact when disabled)

## Test plan
- [ ] Verify artifacts upload with unique names on retry/re-run
- [ ] Confirm digest guard fails on non-digest image refs
- [ ] Test cosign verify path (when enabled)

Safe to merge.