### PR TITLE
fix(ui): update card paths for ResultEnvelope wrapper

### DIFF
--- a/app-pack/ui/cards/hoss-validate.card.yaml
+++ b/app-pack/ui/cards/hoss-validate.card.yaml
@@ -21,7 +21,7 @@ spec:
       error: red
 
   fields:
-    - path: status
+    - path: result.data.status
       label: Status
       type: badge
       mapping:
@@ -29,48 +29,48 @@ spec:
         warning: Warning
         error: Failed
 
-    - path: counts.validated
+    - path: result.data.counts.validated
       label: Diagrams Validated
       type: number
 
-    - path: counts.warnings
+    - path: result.data.counts.warnings
       label: Warnings
       type: number
       highlight: true
 
-    - path: counts.failures
+    - path: result.data.counts.failures
       label: Failures
       type: number
       highlight: true
 
-    - path: tool.version
+    - path: result.data.tool.version
       label: Tool Version
       type: text
 
-    - path: tool.imageDigest
+    - path: result.data.tool.imageDigest
       label: Image Digest
       type: digest
       truncate: 12
 
-    - path: timestamp
+    - path: result.data.timestamp
       label: Validated At
       type: timestamp
 
   sections:
     - title: Validation Details
       fields:
-        - status
-        - counts.validated
-        - counts.warnings
-        - counts.failures
+        - result.data.status
+        - result.data.counts.validated
+        - result.data.counts.warnings
+        - result.data.counts.failures
 
     - title: Tool Information
       fields:
-        - tool.version
-        - tool.imageDigest
-        - timestamp
+        - result.data.tool.version
+        - result.data.tool.imageDigest
+        - result.data.timestamp
 
     - title: Validated Files
       collapsible: true
-      field: matrix
+      field: result.data.matrix
       type: list


### PR DESCRIPTION
## Problem
The envelope format now uses Demon's ResultEnvelope wrapper with the data payload nested under `result.data`:
```json
{
  "result": {
    "success": true,
    "data": {
      "status": "ok",
      "counts": {...},
      "tool": {...}
    }
  }
}
```

The UI card was referencing root-level paths (`status`, `counts.*`) which won't render correctly.

## Solution
Updated all field paths in `app-pack/ui/cards/hoss-validate.card.yaml` to reference `result.data.*`:
- `status` → `result.data.status`
- `counts.*` → `result.data.counts.*`
- `tool.*` → `result.data.tool.*`
- `timestamp` → `result.data.timestamp`
- `matrix` → `result.data.matrix`

## Context
- The contract schema (`validate.result.json`) describes the data payload structure
- The outer `result` wrapper is the platform's ResultEnvelope format
- This ensures correct field rendering in Operate UI regardless of auto-unwrap behavior

## Testing
Will verify with E2E tests (Days 8-10) to ensure card renders correctly with actual envelopes.