### PR TITLE
docs(readme): remove RC1 workspace mount workaround note

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ DEMON_DEBUG=1 DEMON_APP_HOME=/tmp/app-home DEMON_CONTAINER_USER=1000:1000 \
   demonctl run hoss:hoss-validate
 ```
 
-**Note**: RC1 has a known Demon workspace mount issue. Use manual Docker execution as workaround (see release notes).
-
 ### Install from Source
 
 ```bash


### PR DESCRIPTION
## Summary
Remove RC1 workspace mount workaround note from README. The issue has been resolved in Demon.

## Changes
- Removed the note: "RC1 has a known Demon workspace mount issue. Use manual Docker execution as workaround (see release notes)."
- Keep "Install with Demon" instructions unchanged (no functional changes)

## Background
**Demon PR #267** (merged 2025-10-11, SHA `52884c7b`) fixed the workspace mount issue that affected RC1.

**Post-fix validation confirmed** (2025-10-12):
- demonctl version: 0.0.1
- Demon main SHA: 52884c7b42be8dd62763c3a06f445f2d2a8be610
- HHFAB version: v0.41.3
- HHFAB digest: ghcr.io/afewell-hh/hoss/hhfab@sha256:54814bbf4e8459cfb35c7cf8872546f0d5d54da9fc317ffb53eab0e137b21d7b
- Result: `validated=1, warnings=0, failures=0`

## References
- Demon PR #267: Workspace mount fix
- Demon PR #268: Documentation updates (merged 2025-10-12)
- HOSS #53: Wave B dispatch and Demon fix relay

Part of Wave B GA readiness tasks.